### PR TITLE
Fix key prefix for pretrained MHT weights in `mht_encoder.py`

### DIFF
--- a/neuralplexer/model/mht_encoder.py
+++ b/neuralplexer/model/mht_encoder.py
@@ -268,7 +268,7 @@ def _resolve_ligand_encoder(ligand_model_config, task_config):
                 for k, v in torch.load(ligand_model_config.checkpoint_file)[
                     "state_dict"
                 ].items()
-                if k.startswith("encoder_stack")
+                if k.startswith("ligand_encoder")
             }
             model.load_state_dict(pretrained_dict)
         except:


### PR DESCRIPTION
* Fixes the key prefix for pretrained MHT weights in `mht_encoder.py` to enable reloading of these weights as desired
* This fix comes from loading the `complex_structure_prediction.ckpt` weights and printing out the names of the keys in its `state_dict` attribute: 
![image](https://github.com/zrqiao/NeuralPLexer/assets/7051982/af35d4e5-2fb2-4fb6-af0e-61f4f25c1e55)
